### PR TITLE
`.prettierignore`を削除

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,0 @@
-# Generated files
-.astro
-/src/env.d.ts
-/dist
-
-# WebStorm
-/.idea


### PR DESCRIPTION
Prettier v3以降では`.prettierignore`の代わりに`.gitignore`が参照されるため https://prettier.io/blog/2023/07/05/3.0.0.html#ignore-gitignored-files-by-default-14731httpsgithubcomprettierprettierpull14731-by-fiskerhttpsgithubcomfisker