### PR TITLE
記事ページのOGP画像生成時にフォントと画像データが複数回読み込まれるのを修正

### DIFF
--- a/src/utils/lazy.ts
+++ b/src/utils/lazy.ts
@@ -1,0 +1,22 @@
+/**
+ * 指定されたファクトリ関数を遅延評価するラッパー関数を生成する。
+ *
+ * ラッパー関数はファクトリ関数を実行しその結果を返す。ただし、実際にファクトリ関数を実行するのは最初の呼び出し時のみ。
+ * 2回目以降の呼び出しでは、最初の呼び出し時に生成された結果を返す。
+ *
+ * 2回目以降の呼び出し時点で最初の呼び出しが完了していない場合は、完了するまで待機する。
+ *
+ * @param factory 遅延評価するファクトリ関数
+ * @returns ラッパー関数
+ */
+export function lazy<T>(factory: () => Promise<T>): () => Promise<T> {
+  let promise: Promise<T> | undefined
+
+  return () => {
+    if (promise === undefined) {
+      promise = factory()
+    }
+
+    return promise
+  }
+}


### PR DESCRIPTION
`createOgImage`において、1回目の実行でフォントデータを読み込んでいる間に2回目以降の実行が発生すると再度フォントデータの読み込みが発生するのを修正した。

手元での実験では、OGP画像1枚あたりの生成時間が80～100msから20～30msに短縮された。