### PR TITLE
講習会ページのレイアウトをflexからgridへ更新

### DIFF
--- a/src/components/workshop/Workshop2025Section.astro
+++ b/src/components/workshop/Workshop2025Section.astro
@@ -79,7 +79,7 @@ const dateFormat = new Intl.DateTimeFormat('ja-JP', {
       2025年度の講習会について情報をまとめています。開始時刻や開催場所などの詳細や他の講習会については随時更新します。是非お気軽にご参加ください！
     </p>
     <p>各回1～3時間程度の予定となっています。途中退室も可能です。</p>
-    <ul class="flex flex-wrap gap-5">
+    <ul class="grid grid-cols-[repeat(auto-fit,minmax(18rem,1fr))] gap-5">
       {
         items.map(({ date, ...item }) => (
           <WorkshopCard {...item} date={dateFormat.format(date)} />

--- a/src/components/workshop/WorkshopCard.astro
+++ b/src/components/workshop/WorkshopCard.astro
@@ -11,7 +11,7 @@ const { title, date, description, place } = Astro.props
 ---
 
 <li
-  class="flex min-w-[18rem] flex-1 flex-col gap-2 rounded-xl border border-slate-300 bg-white p-5 drop-shadow"
+  class="flex flex-1 flex-col gap-2 rounded-xl border border-slate-300 bg-white p-5 drop-shadow"
 >
   <h2 class="text-xl font-bold">{title}</h2>
   <p class="flex items-center gap-2 text-slate-600">


### PR DESCRIPTION
flexはカードが奇数個のときに最後のカードが長くなってしまうため、gridを使うようにします